### PR TITLE
Fix DeprecationWarning: asyncio.iscoroutinefunction on Python 3.14

### DIFF
--- a/Week05/test_awaitme.py
+++ b/Week05/test_awaitme.py
@@ -1,5 +1,6 @@
 import os
 import asyncio
+import inspect
 
 
 files = [f for f in os.listdir(os.path.dirname(__file__)) if f.startswith("awaitme")]
@@ -23,8 +24,8 @@ def test_awaitable():
         @eval(f[:-3]).awaitme
         def dummy_function(x: int = 0, y: int = 0) -> int:
             return x + y
-        assert asyncio.iscoroutinefunction(dummy_awaitable), "awaitme is not awaitable in " + f[:-3]
-        assert asyncio.iscoroutinefunction(dummy_function), "awaitme is not awaitable in " + f[:-3]
+        assert inspect.iscoroutinefunction(dummy_awaitable), "awaitme is not awaitable in " + f[:-3]
+        assert inspect.iscoroutinefunction(dummy_function), "awaitme is not awaitable in " + f[:-3]
 
 def test_values():
     for f in files:


### PR DESCRIPTION
## Describe the changes
While running the tests locally on Python 3.14, I noticed a DeprecationWarning regarding `asyncio.iscoroutinefunction`. Since this is slated for [removal in 3.16](https://github.com/python/cpython/pull/122875), I’ve updated the `test_awaitable` method to use `inspect.iscoroutinefunction` to ensure future compatibility. We use Python 3.12 i know but this is a good practice to avoid deprecation warnings and ensure the code remains functional in future Python versions.


### Warning Message
```Week05/test_awaitme.py::test_awaitable
  /home/mert/School/parallel-programming/Week05/test_awaitme.py:26: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    assert asyncio.iscoroutinefunction(dummy_awaitable), "awaitme is not awaitable in " + f[:-3]
```
```
Week05/test_awaitme.py::test_awaitable
  /home/mert/School/parallel-programming/Week05/test_awaitme.py:27: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    assert asyncio.iscoroutinefunction(dummy_function), "awaitme is not awaitable in " + f[:-3]
```

## Expected Behavior
No deprecation warnings. asyncio.iscoroutinefunction should be replaced with inspect.iscoroutinefunction.
inspect.iscoroutinefunction [is available since Python 3.5](https://docs.python.org/3/library/inspect.html#inspect.iscoroutinefunction), so this is fully backward-compatible.

Does this look okay to merge?

## Checklist
- [x] I have read the [CONTRIBUTING]
- [x] I have performed a self-review of my own code
- [x] I have run the code locally and it works as expected